### PR TITLE
Expose DocumentFields and Create Envelope with Document Objects

### DIFF
--- a/DocuSign.Integrations.Client/DocuSignClientUnitTests/EnvelopeTest.cs
+++ b/DocuSign.Integrations.Client/DocuSignClientUnitTests/EnvelopeTest.cs
@@ -3,6 +3,7 @@ using DocuSign.Integrations.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace RestClientUnitTests
 {
@@ -16,6 +17,7 @@ namespace RestClientUnitTests
     public class EnvelopeTest
     {
 
+        private static Account _account;
 
         private TestContext testContextInstance;
 
@@ -40,11 +42,30 @@ namespace RestClientUnitTests
         //You can use the following additional attributes as you write your tests:
         //
         //Use ClassInitialize to run code before running the first test in the class
-        //[ClassInitialize()]
-        //public static void MyClassInitialize(TestContext testContext)
-        //{
-        //}
-        //
+        [ClassInitialize()]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            ConfigLoader.LoadConfig();
+            // $TODO: Add creds for known account
+            _account = new Account
+            {
+                Email = "",
+                Password = "",
+                AccountName = ""
+            };
+
+
+            try
+            {
+                if (!_account.Login())
+                    Assert.Fail("Unexpected exception during account creation part of test {0}: {1}", _account.RestError.errorCode, _account.RestError.message);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Unexpected exception during account creation part of test {0}: {1}", ex.GetType(), ex.Message);
+            }
+        }
+
         //Use ClassCleanup to run code after all tests in a class have run
         //[ClassCleanup()]
         //public static void MyClassCleanup()
@@ -469,6 +490,67 @@ namespace RestClientUnitTests
             Assert.AreEqual(target.Recipients.signers[2].email, "test3@docusign20154.onmicrosoft.com");
             Assert.AreEqual(target.Recipients.signers[2].name, "Test Three");
             Assert.AreEqual(target.Recipients.signers[2].status, "created");
+        }
+
+        /// <summary>
+        ///A test for Create
+        ///</summary>
+        [TestMethod(), DeploymentItem("Test Contract.pdf")]
+        public void EnvelopeCreateWithDocumentObjectsAndGetDocumentFieldsTest()
+        {
+            const bool expected = true;
+            const string expectedDocumentAttributeName = "Document Attribute Name";
+            const string expectedDocumentAttributeValue = "Document Attribute Value";
+            var actual = false;
+
+            Assert.IsFalse(string.IsNullOrEmpty(_account.BaseUrl));
+
+            var target = new Envelope { Login = _account };
+            var fi = new FileInfo("./Test Contract.pdf");
+
+            var documentCustomFields = new List<DocumentField>
+            {
+                new DocumentField {name = expectedDocumentAttributeName, value = expectedDocumentAttributeValue}
+            };
+            var documents = new List<Document>
+            {
+                new Document
+                {
+                    attachmentDescription = fi.Name.Replace(fi.Extension, string.Empty),
+                    documentId = "1",
+                    documentFields = documentCustomFields.ToArray(),
+                    fileExtension = fi.Extension,
+                    name = fi.Name
+                }
+            };
+
+            var fileBytes = new List<Byte[]> { File.ReadAllBytes(fi.FullName) };
+
+            try
+            {
+                actual = target.Create(fileBytes, documents);
+            }
+            catch (ArgumentNullException)
+            {
+            }
+
+            Assert.AreEqual(expected, actual);
+            Assert.IsFalse(string.IsNullOrEmpty(target.SenderViewUrl));
+            var actualDocuments = target.GetDocuments();
+            Assert.AreEqual(documents.Count, actualDocuments.Count);
+            for (var i = 0; i < documents.Count; i++)
+            {
+                Assert.AreEqual(documents[i].documentId, actualDocuments[i].documentId);
+                Assert.AreEqual(documents[i].name, actualDocuments[i].name);
+
+                var fields = target.GetDocumentFields(documents[i].documentId);
+                Assert.AreEqual(documents[i].documentFields.Count(), fields.documentFields.Count());
+                for (var j = 0; j < documents[i].documentFields.Count(); j++)
+                {
+                    Assert.AreEqual(documents[i].documentFields[j].name, fields.documentFields[j].name);
+                    Assert.AreEqual(documents[i].documentFields[j].value, fields.documentFields[j].value);
+                }
+            }
         }
     }
 }

--- a/DocuSign.Integrations.Client/Envelope.json.cs
+++ b/DocuSign.Integrations.Client/Envelope.json.cs
@@ -302,6 +302,30 @@ namespace DocuSign.Integrations.Client
     }
 
     /// <summary>
+    /// Json class for document fields.
+    /// </summary>
+    [Serializable]
+    public class DocumentFields
+    {
+        public DocumentField[] documentFields;
+
+        public static DocumentFields FromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<DocumentFields>(json);
+        }
+    }
+
+    /// <summary>
+    /// A name-value pair that provides custom data for a document.
+    /// </summary>
+    [Serializable]
+    public class DocumentField
+    {
+        public string name { get; set; }
+        public string value { get; set; }
+    }
+
+    /// <summary>
     /// Json class for documents
     /// </summary>
     [Serializable]
@@ -338,6 +362,12 @@ namespace DocuSign.Integrations.Client
         /// Gets or sets the transform pdf fields property
         /// </summary>
         public string transformPdfFields { get; set; }
+
+        /// <summary>
+        /// An optional array of name-value strings that allows the sender to provide custom data for a document. 
+        /// This information is returned in the envelope status but otherwise not used by DocuSign.
+        /// </summary>
+        public DocumentField[] documentFields { get; set; }
 
         /// <summary>
         /// Gets or sets the file extension property


### PR DESCRIPTION
- Created GetDocumentFields function.
- Added GetEnvelopeDocumentInfo with no parameters, since you're getting the document info from an instance of an envelope.
- Created CreateJson with List<Document> to be added to the EnvelopeCreate instead of a List<string> and startIndex.
- Created Create with the List<Byte[]> of file data and List<Document> of documents.

Envelope.json.cs
- Added DocumentFields class for json transmission of the document custom data.
- Added DocumentField for json transmission of one set of document custom data.
- Added a DocumentField array to the Document class so that its included in the outgoing json.

EnvelopeTest
- Created a static variable in the test class that is initialized during the ClassInitialize.
- Added EnvelopeCreateWithDocumentObjectsAndGetDocumentFieldsTest to test creating an envelope using document objects and getting the document fields from the documents.