### PR TITLE
Incorporated a PR and added the accessCode parameter.

### DIFF
--- a/DocuSign.Integrations.Client/Envelope.cs
+++ b/DocuSign.Integrations.Client/Envelope.cs
@@ -2370,7 +2370,7 @@ namespace DocuSign.Integrations.Client
                 req.BaseUrl = this.Login.BaseUrl;
                 req.LoginEmail = this.Login.Email;
                 req.ApiPassword = this.Login.ApiPassword;
-                req.Uri = "/envelopes?api_password=true&from_date=" + fromDate.ToString();
+                req.Uri = "/envelopes?api_password=true&from_date=" + fromDate.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'");
                 req.HttpMethod = "GET";
                 req.IntegratorKey = RestSettings.Instance.IntegratorKey;
                 req.IsMultipart = true;

--- a/DocuSign.Integrations.Client/Envelope.json.cs
+++ b/DocuSign.Integrations.Client/Envelope.json.cs
@@ -256,6 +256,10 @@ namespace DocuSign.Integrations.Client
         /// Each customField string can be a maximum of 100 characters.
         /// </summary>
         public string[] customFields { get; set; }
+        /// <summary>
+        /// Sets the access code that the recipient must enter before opening the document.
+        /// </summary>
+        public string accessCode { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
We need the accessCode to protect a signed document. This adds the accessCode to the signer class. I pulled in another PR that was useful too. 

If you see line ending changes then add "?w=1" to the end of the address bar URL and the whitespace will be ignored.