### PR TITLE
Include usage of SendOnBehalfOf within Envelope.Create(filepath)

### DIFF
--- a/DocuSign.Integrations.Client/Envelope.cs
+++ b/DocuSign.Integrations.Client/Envelope.cs
@@ -1562,6 +1562,12 @@ namespace DocuSign.Integrations.Client
                 req.MultipartBoundary = new Guid().ToString();
                 builder.Proxy = this.Proxy;
 
+                if (string.IsNullOrWhiteSpace(this.Login.SOBOUserId) == false)
+                {
+                    req.SOBOUserId = this.Login.SOBOUserId;
+                    builder.AuthorizationFormat = RequestBuilder.AuthFormat.Json;
+                }
+
                 RequestBody rb = new RequestBody();
                 rb.Headers.Add("Content-Type", "application/json");
                 rb.Headers.Add("Content-Disposition", "form-data");


### PR DESCRIPTION
The SOBOUserID field was not being added to the request within the envelope creation method that only accepts a filepath (Envelope.Create(filePath).  SendOnBehalfOf functionality would not work.

Mentioned here on [StackOverflow](http://stackoverflow.com/questions/30238353/docusign-net-client-and-send-on-behalf-ofsobo).

This commit fixes #69 